### PR TITLE
ORG is now pulled in via API_USERNAME

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@ to get list of commands: `bundle exec thor list`
 
 then you can issue a command such as walk. 
 
-   `bundle exec thor walk:vdcs <ORG-ID>`
+   `bundle exec thor walk:vdcs`
 
-`bundle exec thor walk:catalogs <ORG-ID>`
+`bundle exec thor walk:catalogs`
 
-`bundle exec thor walk:networks <ORG-ID>`
+`bundle exec thor walk:networks`
 
 you will also need your user details in your environment:
 
-    API_USERNAME
+    API_USERNAME ## <API_USER>@<ORG-ID>
     API_PASSWORD
 


### PR DESCRIPTION
Think its best to indicate that "API_USERNAME" actually requires '@<ORG>' @snehaso 
