### PR TITLE
small tidyups and renames around the use of Fog

### DIFF
--- a/lib/fog_interface.rb
+++ b/lib/fog_interface.rb
@@ -17,13 +17,13 @@ class FogInterface
 
   # we use the request here as we don't yet have a model for Edge Gateways
   def self.get_edge_gateways
-    session = VcloudSession.instance
+    vcloud = VcloudSession.instance
     get_vdcs.collect do |vdc|
-      data = session.get_edge_gateways(vdc.id).body
+      data = vcloud.get_edge_gateways(vdc.id).body
       if data[:EdgeGatewayRecord]
         edge_gateways = data[:EdgeGatewayRecord].is_a?(Hash) ? [data[:EdgeGatewayRecord]] : data[:EdgeGatewayRecord]
         edge_gateways.map do |edgeGateway|
-         session.get_edge_gateway(edgeGateway[:href].split('/').last).body
+         vcloud.get_edge_gateway(edgeGateway[:href].split('/').last).body
         end
       end
     end.flatten.compact
@@ -36,8 +36,8 @@ class FogInterface
 
   private
   def self.get_org
-    session = VcloudSession.instance
-    session.organizations.get_by_name(session.org_name)
+    vcloud = VcloudSession.instance
+    vcloud.organizations.get_by_name(vcloud.org_name)
   end
 
 end

--- a/lib/vcloud_session.rb
+++ b/lib/vcloud_session.rb
@@ -1,18 +1,15 @@
 class VcloudSession
 
   API_URL = 'api.vcd.portal.skyscapecloud.com'
-  API_VERSION = '5.1'
-  TIMEOUT = 200
 
   def self.instance
     raise ArgumentError.new('API credentials not found !') unless ENV['API_USERNAME'] && ENV['API_PASSWORD']
 
     Fog::Compute::VcloudDirector.new(
-        :vcloud_director_host => API_URL,
-        :vcloud_director_username => ENV['API_USERNAME'],
-        :vcloud_director_password => ENV['API_PASSWORD'],
-        :vcloud_director_api_version => API_VERSION,
-        :connection_options => {:omit_default_port => true, :connect_timeout => TIMEOUT, :read_timeout => TIMEOUT})
+      :vcloud_director_host => API_URL,
+      :vcloud_director_username => ENV['API_USERNAME'],
+      :vcloud_director_password => ENV['API_PASSWORD'],
+    )
   end
 
 end

--- a/spec/walk/vcloud_session_spec.rb
+++ b/spec/walk/vcloud_session_spec.rb
@@ -18,9 +18,7 @@ describe VcloudSession do
       Fog::Compute::VcloudDirector.should_receive(:new)
                                   .with(:vcloud_director_host => 'api.vcd.portal.skyscapecloud.com',
                                         :vcloud_director_username => 'correct-user',
-                                        :vcloud_director_password => 'correct-password',
-                                        :vcloud_director_api_version => '5.1',
-                                        :connection_options => {:omit_default_port => true, :connect_timeout => 200, :read_timeout => 200})
+                                        :vcloud_director_password => 'correct-password')
                                   .and_return(mock_session)
 
       VcloudSession.instance.should == mock_session


### PR DESCRIPTION
- renamed session to vcloud
- stopped passing params to fog that are now unneeded

/cc @snehaso 
