### PR TITLE
additional copy and markdown tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # VCloud Walker
 
-Vcloud-walker is a command line tool, to describe different vcloud entities.
+Vcloud-walker is a command line tool, to describe different VMware vCloud Director 5.1 entities. It uses Fog under
+the hood.
 
 ## Usage
 To find usage, run `bundle exec thor list`.
@@ -8,40 +9,41 @@ To find usage, run `bundle exec thor list`.
 You can perform following operations with walker.
 
 #### Walk vdcs :
-<pre>`bundle exec thor vcloud_walk:vdcs` </pre>         
-describes all vdcs within given organization. This include vapp, vm and network information
-<br/><br/>
+    bundle exec thor vcloud_walk:vdcs
+
+describes all vdcs within given organization. This includes vapp, vm and network information
 
 #### Walk catalogs:
-<pre> `bundle exec thor vcloud_walk:catalogs` </pre>     
+    bundle exec thor vcloud_walk:catalogs
+
 describes all catalogs and catalog items within given organization.
-<br/><br/>
 
 #### Walk organization networks : 
-<pre> `bundle exec thor vcloud_walk:networks` </pre>      
+     bundle exec thor vcloud_walk:networks
+
 describes all organization networks
-<br/><br/>
 
 #### Walk edgegateways :
-<pre> `bundle exec thor vcloud_walk:edgegateways` </pre>   
-describes all edgegateway for given organization. Each edgegateway includes configuration for firewall, load balancer and nat services.
-<br/><br/>
+    bundle exec thor vcloud_walk:edgegateways
+
+describes all edgegateway for given organization. Each edgegateway includes configuration for firewall, load balancer
+and nat services.
+
 ### Credentials
 
-You will need credentials for your vmware environment. Vcloud-walker internally uses fog to query vmware api.
-You need to create .fog.To understand how to write .fog file, check 'Credentials' section here => http://fog.io/about/getting_started.html.
+You will need to specify the credentials for your vmware environment. As Vcloud-walker uses fog to query the vmware api,
+you will need to create a `.fog` file containing these credentials.
 
 An example of .fog file is:
-<pre>
+````
 default:
   vcloud_director_username: 'user_id@org_id'
   vcloud_director_password: 'password'
   vcloud_director_host: 'api_endpoint'
-</pre>  
-<br/> 
-  
+````
+
+To understand more about `.fog` files, visit the 'Credentials' section here => http://fog.io/about/getting_started.html.
+
 ### Output
 
 The output is in JSON format. Find sample output look into docs/examples directory. 
-
-


### PR DESCRIPTION
I've added a little more context for first time readers and changed from HTML to markdown where I can.

I wanted to link to the docs/examples directory but can't see how

/cc @snehaso 
