### PR TITLE
fix starting and stopping boxes for integration tests run

### DIFF
--- a/scripts/switch_power_for_walker_ci.rb
+++ b/scripts/switch_power_for_walker_ci.rb
@@ -1,4 +1,4 @@
-require File.expand_path("../../lib/walk/walk.rb", __FILE__)
+require 'vcloud/walker'
 
 usage = 'bundle exec ruby script/switch_power_for_walker_ci.rb (on/off)'
 unless ARGV.count == 1 && %w(on off).include?(ARGV[0])
@@ -8,7 +8,7 @@ end
 
 power_mode = ARGV[0]
 
-org = FogInterface.get_org
+org = Vcloud::Walker::FogInterface.get_org
 vdc = org.vdcs.get_by_name('vCloud CI (IL2-DEVTEST-BASIC)')
 vapp = vdc.vapps.get_by_name 'vcloud-walker-contract-testing-vapp'
 response = vapp.send("power_#{power_mode}")


### PR DESCRIPTION
The code that switches on and off the boxes for the integration test needs to include code using the refactored paths

This code probably needs to migrate to be using vcloud tools - I'll raise a chore to look at this

/cc @annashipman @mikepea 
