### PR TITLE
Walker should report compute metadata

### DIFF
--- a/lib/vcloud/walker/resource/entity.rb
+++ b/lib/vcloud/walker/resource/entity.rb
@@ -16,6 +16,11 @@ module Vcloud
           h
         end
 
+        private
+        def extract_id(href)
+          href.split('/').last
+        end
+
       end
     end
   end

--- a/lib/vcloud/walker/resource/vapp.rb
+++ b/lib/vcloud/walker/resource/vapp.rb
@@ -5,10 +5,11 @@ module Vcloud
         attr_reader :id, :name, :status, :description, :network_config, :vms, :deployed, :network_section
 
         def initialize fog_vapp
-          [:name, :status, :deployed, :id, :Description].each do |key|
-            instance_variable_set("@#{key.downcase}", fog_vapp[key])
-          end
-
+          @name = fog_vapp[:name]
+          @status = fog_vapp[:status]
+          @description = fog_vapp[:Description]
+          @deployed = fog_vapp[:deployed]
+          @id = extract_id(fog_vapp[:href])
           @network_config  = extract_network_config(fog_vapp[:NetworkConfigSection][:NetworkConfig])
           @network_section = fog_vapp[:'ovf:NetworkSection'][:'ovf:Network']
           @vms             = Resource::Vms.new(fog_vapp[:Children][:Vm])

--- a/lib/vcloud/walker/resource/vm.rb
+++ b/lib/vcloud/walker/resource/vm.rb
@@ -19,9 +19,8 @@ module Vcloud
                     :network_cards
 
         def initialize fog_vm
-          [:id, :status].each do |key|
-            instance_variable_set("@#{key.downcase}", fog_vm[key])
-          end
+          @id = extract_id(fog_vm[:href])
+          @status = fog_vm[:status]
           @operating_system = fog_vm[:'ovf:OperatingSystemSection'][:'ovf:Description']
           @network_connections = fog_vm[:NetworkConnectionSection][:NetworkConnection] if fog_vm[:NetworkConnectionSection]
           @primary_network_connection_index = fog_vm[:NetworkConnectionSection][:PrimaryNetworkConnectionIndex]
@@ -33,6 +32,7 @@ module Vcloud
             :name => fog_vm[:StorageProfile][:name],
           }
         end
+
 
         private
         def extract_compute_capacity ovf_resources

--- a/spec/stubs/service_layer_stub.rb
+++ b/spec/stubs/service_layer_stub.rb
@@ -1,59 +1,69 @@
 module Fog
   module ServiceLayerStub
-    def self.mock_vapp
-      body = {:name => "vapp-atomic-centre",
-              :id => 1,
-              :status => "on",
-              :description => "hosts the atomic centre app",
-              :deployed => true,
-              :NetworkConfigSection => {:NetworkConfig => [{:networkName => "Default", :IsDeployed => true, :Description => "default network",
-                                                            :Configuration => {:IpScopes => 'abc'}, :ParentNetwork => nil}]},
-              :"ovf:NetworkSection" => {:'ovf:Network' => 'network'},
-              :Children => {
-                  :Vm =>
-                      {
-                          :needsCustomization => "true",
-                          :deployed => "true",
-                          :status => "4", :name => "ubuntu-precise-201309091031",
-                          :id => "urn:vcloud:vm:d19d84a5-c950-4497-a638-23eccc4226a5",
-                          :type => "application/vnd.vmware.vcloud.vm+xml",
-                          :href => "https://api.vcd.portal.examplecloud.com/api/vApp/vm-d19d84a5-c950-4497-a638-23eccc4226a5",
-                          :Description => "ubuntu-precise | Version: 1.0 | Built using BoxGrinder",
-                          :"ovf:OperatingSystemSection" =>
-                              {
-                                  :"ovf:Description" => "Ubuntu Linux (64-bit)",
-                              },
-                          :NetworkConnectionSection => {
-                              :ovf_required => "false",
-                              :"ovf:Info" => "Specifies the available VM network connections",
-                              :PrimaryNetworkConnectionIndex => "0",
-                              :NetworkConnection =>
-                                  {
-                                      :network => "Default",
-                                      :needsCustomization => "true",
-                                      :NetworkConnectionIndex => "0",
-                                      :IpAddress => "192.168.2.2",
-                                      :IsConnected => "true",
-                                      :MACAddress => "00:50:56:01:0b:1a",
-                                      :IpAddressAllocationMode => "MANUAL"},
-
-                          },
-                          :'ovf:VirtualHardwareSection' => {
-                              :'ovf:Item' => [],
-                              :"ovf:System" => {:"vssd:ElementName" => "Virtual Hardware Family", :"vssd:VirtualSystemType" => "vmx-08"}
-                          },
-                          :RuntimeInfoSection => {
-                              :VMWareTools => {:version => "2147483647"}
-                          },
-                          :StorageProfile => {
-                                  :type=>"application/vnd.vmware.vcloud.vdcStorageProfile+xml",
-                                  :name=>"TEST-STORAGE-PROFILE",
-                                  :href=>"https://api.vcd.portal.examplecloud.com/api/vdcStorageProfile/00000000-aaaa-bbbb-aaaa-000000000000"
-                              }
-                      }
-              }
+    def self.vapp_body
+      {:name => "vapp-atomic-centre",
+       :id => "urn:vcloud:vm:aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+       :href => 'https://myvdc.carrenza.net/api/vApp/vapp-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+       :status => "on",
+       :description => "hosts the atomic centre app",
+       :deployed => true,
+       :NetworkConfigSection => {:NetworkConfig => [{:networkName => "Default", :IsDeployed => true, :Description => "default network",
+                                                     :Configuration => {:IpScopes => 'abc'}, :ParentNetwork => nil}]},
+       :"ovf:NetworkSection" => {:'ovf:Network' => 'network'},
+       :Children =>
+           {
+               :Vm =>
+                   {
+                       :needsCustomization => "true",
+                       :deployed => "true",
+                       :status => "4", :name => "ubuntu-precise-201309091031",
+                       :id => "urn:vcloud:vm:d19d84a5-c950-4497-a638-23eccc4226a5",
+                       :type => "application/vnd.vmware.vcloud.vm+xml",
+                       :href => "https://api.vcd.portal.examplecloud.com/api/vApp/vm-d19d84a5-c950-4497-a638-23eccc4226a5",
+                       :Description => "ubuntu-precise | Version: 1.0 | Built using BoxGrinder",
+                       :"ovf:OperatingSystemSection" =>
+                           {
+                               :"ovf:Description" => "Ubuntu Linux (64-bit)"
+                           },
+                       :NetworkConnectionSection =>
+                           {
+                               :ovf_required => "false",
+                               :"ovf:Info" => "Specifies the available VM network connections",
+                               :PrimaryNetworkConnectionIndex => "0",
+                               :NetworkConnection =>
+                                   {
+                                       :network => "Default",
+                                       :needsCustomization => "true",
+                                       :NetworkConnectionIndex => "0",
+                                       :IpAddress => "192.168.2.2",
+                                       :IsConnected => "true",
+                                       :MACAddress => "00:50:56:01:0b:1a",
+                                       :IpAddressAllocationMode => "MANUAL"
+                                   },
+                           },
+                       :'ovf:VirtualHardwareSection' =>
+                           {
+                               :'ovf:Item' => [],
+                               :"ovf:System" =>
+                                   {:"vssd:ElementName" => "Virtual Hardware Family", :"vssd:VirtualSystemType" => "vmx-08"}
+                           },
+                       :RuntimeInfoSection =>
+                           {
+                               :VMWareTools => {:version => "2147483647"}
+                           },
+                       :StorageProfile =>
+                           {
+                               :type => "application/vnd.vmware.vcloud.vdcStorageProfile+xml",
+                               :name => "TEST-STORAGE-PROFILE",
+                               :href => "https://api.vcd.portal.examplecloud.com/api/vdcStorageProfile/00000000-aaaa-bbbb-aaaa-000000000000"
+                           }
+                   }
+           }
       }
-      RSpec::Mocks::Mock.new(:fog_vapp, :body => body)
+    end
+
+    def self.mock_vapp
+      RSpec::Mocks::Mock.new(:fog_vapp, :body => vapp_body)
     end
 
     def self.hardware_resources

--- a/spec/walk/vm_spec.rb
+++ b/spec/walk/vm_spec.rb
@@ -9,6 +9,7 @@ describe Vcloud::Walker::Resource::Vm do
           :status => "8",
           :name => "ubuntu-testing-template",
           :id => "urn:vcloud:vm:aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+          :href => 'https://myvdc.carrenza.net/api/vApp/vm-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
           :"ovf:VirtualHardwareSection" =>
               {:"ovf:Info" => "Virtual hardware requirements",
                :"ovf:System" => {:"vssd:ElementName" => "Virtual Hardware Family", :"vssd:VirtualSystemType" => "vmx-08"},
@@ -49,6 +50,10 @@ describe Vcloud::Walker::Resource::Vm do
       }
 
       @vm_summary = Vcloud::Walker::Resource::Vm.new(fog_vm)
+    end
+
+    it 'should report id from the href' do
+      @vm_summary.id.should == 'vm-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'
     end
 
     it "should populate vmware tool version" do


### PR DESCRIPTION
walker used to report ids in wrong format which cant be used to query vcloud.

old format : `urn:vcloud:vapp:aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee`
new format: `vapp-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee`

@danielabel  & Sneha
