### PR TITLE
spec - vapp should have id in correct format

### DIFF
--- a/spec/walk/vapp_spec.rb
+++ b/spec/walk/vapp_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe Vcloud::Walker::Resource::VApp do
+
+  context 'populate summary vapp model' do
+    before(:all) do
+      fog_vapp = Fog::ServiceLayerStub.vapp_body
+
+      @vm_summary = Vcloud::Walker::Resource::VApp.new(fog_vapp)
+    end
+
+    it 'should report id from the href' do
+      @vm_summary.id.should == 'vapp-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'
+    end
+  end
+end


### PR DESCRIPTION
forgot to checkin this spec in last commit.

cc @danielabel 
