### PR TITLE
using resource type to extract vm resources

### DIFF
--- a/lib/vcloud/walker/resource/vm.rb
+++ b/lib/vcloud/walker/resource/vm.rb
@@ -18,6 +18,13 @@ module Vcloud
                     :virtual_system_type, :network_connections, :storage_profile,
                     :network_cards
 
+        HARDWARE_RESOURCE_TYPES = {
+            :cpu => '3',
+            :memory => '4',
+            :hard_disk => '17',
+            :network_adapter => '10'
+        }
+
         def initialize fog_vm
           @id = extract_id(fog_vm[:href])
           @status = fog_vm[:status]
@@ -40,15 +47,15 @@ module Vcloud
         end
 
         def extract_cpu(resources)
-          @cpu = resources.detect { |element| element[:'rasd:Description']=='Number of Virtual CPUs' }[:'rasd:ElementName']
+          @cpu = resources.detect { |element| element[:'rasd:ResourceType']== HARDWARE_RESOURCE_TYPES[:cpu] }[:'rasd:ElementName']
         end
 
         def extract_memory(resources)
-          @memory = resources.detect { |element| element[:'rasd:Description']=='Memory Size' }[:'rasd:ElementName']
+          @memory = resources.detect { |element| element[:'rasd:ResourceType']== HARDWARE_RESOURCE_TYPES[:memory] }[:'rasd:ElementName']
         end
 
         def extract_disks(resources)
-          disk_resources = resources.select { |element| element[:'rasd:Description']=='Hard disk' }
+          disk_resources = resources.select { |element| element[:'rasd:ResourceType']== HARDWARE_RESOURCE_TYPES[:hard_disk] }
           @disks = disk_resources.collect do |d|
             {:name => d[:'rasd:ElementName'], :size => d[:'rasd:HostResource'][:'ns12_capacity'].to_i}
           end
@@ -56,7 +63,7 @@ module Vcloud
 
         def extract_network_cards(resources)
           resources = resources.select {
-            |element| element[:'rasd:ResourceType'] == "10"
+            |element| element[:'rasd:ResourceType'] == HARDWARE_RESOURCE_TYPES[:network_adapter]
           }
           @network_cards = resources.collect do |r|
             {:name => r[:'rasd:ElementName'],

--- a/spec/stubs/service_layer_stub.rb
+++ b/spec/stubs/service_layer_stub.rb
@@ -69,6 +69,7 @@ module Fog
     def self.hardware_resources
       [
           {
+              :'rasd:ResourceType' =>:: Vcloud::Walker::Resource::Vm::HARDWARE_RESOURCE_TYPES[:hard_disk],
               :"rasd:AddressOnParent" => "0",
               :"rasd:Description" => "Hard disk",
               :"rasd:ElementName" => "Hard disk 1",
@@ -76,20 +77,24 @@ module Fog
           },
 
           {
+              :'rasd:ResourceType' => ::Vcloud::Walker::Resource::Vm::HARDWARE_RESOURCE_TYPES[:hard_disk],
               :"rasd:AddressOnParent" => "1",
               :"rasd:Description" => "Hard disk",
               :"rasd:ElementName" => "Hard disk 2",
               :"rasd:HostResource" => {:ns12_capacity => "307200", :ns12_busSubType => "lsilogic", :ns12_busType => "6"}
           },
           {
+              :'rasd:ResourceType' => ::Vcloud::Walker::Resource::Vm::HARDWARE_RESOURCE_TYPES[:cpu],
               :"rasd:Description" => "Number of Virtual CPUs",
               :"rasd:ElementName" => "2 virtual CPU(s)"
           },
           {
+              :'rasd:ResourceType' => ::Vcloud::Walker::Resource::Vm::HARDWARE_RESOURCE_TYPES[:memory],
               :"rasd:Description" => "Memory Size",
               :"rasd:ElementName" => "4096 MB of memory"
           },
           {
+              :'rasd:ResourceType' => ::Vcloud::Walker::Resource::Vm::HARDWARE_RESOURCE_TYPES[:network_adapter],
               :'rasd:Address'     => '00:50:56:00:00:01',
               :'rasd:AddressOnParent' => '0',
               :'rasd:AutomaticAllocation' => true,
@@ -97,7 +102,6 @@ module Fog
               :'rasd:ElementName' => 'Network adapter 0',
               :'rasd:InstanceID'  => '0',
               :'rasd:ResourceSubType' => 'E1000',
-              :'rasd:ResourceType' => '10',
           },
       ]
     end


### PR DESCRIPTION
using description is not reliable since it can be rewritten.
