### PR TITLE
Should allow later version of Fog

### DIFF
--- a/vcloud_walker.gemspec
+++ b/vcloud_walker.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'json', '~> 1.8.0'
   s.add_runtime_dependency 'methadone'
   s.add_runtime_dependency 'thor', '~> 0.18.1'
-  s.add_runtime_dependency 'fog', '~> 1.18.0'
+  s.add_runtime_dependency 'fog', '>= 1.18.0'
   s.add_development_dependency 'simplecov', '~> 0.8.2'
   s.add_development_dependency "jeweler", "~> 1.8.8"
 end


### PR DESCRIPTION
When developing we may be working against a later release version of Fog than the one specificed in the gemspec. Same issue as in vcloud-tools: 9925e5d0f
