### PR TITLE
walker should print yaml output

### DIFF
--- a/bin/vcloud-walker
+++ b/bin/vcloud-walker
@@ -14,11 +14,13 @@ class App
   include Vcloud
 
   main do |resource_to_walk|
-    print JSON.pretty_generate Vcloud::Walker.walk(resource_to_walk)
+    walker_output = Vcloud::Walker.walk(resource_to_walk)
+    options[:yaml] ? print(walker_output.to_yaml)  :  print(JSON.pretty_generate walker_output)
   end
 
   on("--verbose", "Verbose output")
   on("--debug",   "Debugging output")
+  on("--yaml",   "Yaml output")
 
   arg :resource_to_walk
 


### PR DESCRIPTION
walker now takes option(--yaml) to print yaml output.

By default, it will continue printing json(for existing users).

i could not add any tests for this, because that would need cucumber setup for methadone. Ideally we should have setup cucumber as part of https://github.com/alphagov/vcloud-walker/pull/37.  

I will raise a chore to setup cucumber for testing walker cli.
