### PR TITLE
[#69915642] Bump vCloud Core version to 0.0.12 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.2.1 (2014-04-22)
+
+Bugfixes:
+
+  - Requires vCloud Core v0.0.12 which fixes issue with progress bar falling over when progress is not returned
+
 ## 3.2.0 (2014-04-14)
 
 Features:

--- a/lib/vcloud/walker/version.rb
+++ b/lib/vcloud/walker/version.rb
@@ -1,5 +1,5 @@
 module Vcloud
   module Walker
-    VERSION = '3.2.0'
+    VERSION = '3.2.1'
   end
 end

--- a/vcloud-walker.gemspec
+++ b/vcloud-walker.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'json', '~> 1.8.0'
   s.add_runtime_dependency 'methadone'
   s.add_runtime_dependency 'fog', '>= 1.21.0'
-  s.add_runtime_dependency 'vcloud-core', '>= 0.0.11'
+  s.add_runtime_dependency 'vcloud-core', '>= 0.0.12'
   s.add_development_dependency 'simplecov', '~> 0.8.2'
   s.add_development_dependency 'gem_publisher', '1.2.0'
 end


### PR DESCRIPTION
Bump vCloud Core to version 0.0.12, which fixes an issue where tasks
that would show a progress bar fall over which this error message:

```
undefined method `<' for nil:NilClass
```

---

Also corrects the CHANGELOG release date for version 3.2.0.
