### PR TITLE
[#70500696] Use pessimistic version dependency for vcloud-core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.2.2 (2014-05-01)
+
+  - Use pessimistic version dependency for vcloud-core
+
 ## 3.2.1 (2014-04-22)
 
 Bugfixes:

--- a/lib/vcloud/walker/version.rb
+++ b/lib/vcloud/walker/version.rb
@@ -1,5 +1,5 @@
 module Vcloud
   module Walker
-    VERSION = '3.2.1'
+    VERSION = '3.2.2'
   end
 end

--- a/vcloud-walker.gemspec
+++ b/vcloud-walker.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'json', '~> 1.8.0'
   s.add_runtime_dependency 'methadone'
   s.add_runtime_dependency 'fog', '>= 1.21.0'
-  s.add_runtime_dependency 'vcloud-core', '>= 0.0.12'
+  s.add_runtime_dependency 'vcloud-core', '~> 0.0.12'
   s.add_development_dependency 'simplecov', '~> 0.8.2'
   s.add_development_dependency 'gem_publisher', '1.2.0'
 end


### PR DESCRIPTION
Use Ruby's pessimistic operator[1](http://guides.rubygems.org/patterns/#declaring_dependencies) for the version dependency on the
vcloud-core gem, which prevents us from installing a version of
vcloud-core with a greater minor version than the one specified.

In this case, only versions less than 0.1.0 will be installed.

This reinforces our policy of semantic versioning, whereby a minor
version bump may signify that changes in that versions are not backwards
compatible.

Also bump version to 3.2.2 to encourage people to download this version
in anticipation of breaking changes to come soon.
