### PR TITLE
Rename Rake task for integration tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Current
+
+Bugfixes:
+
+  - Rename Rake integration test from 'integration_test' to 'integration' for consistency with other vCloud Tools
+
 ## 3.2.2 (2014-05-01)
 
   - Use pessimistic version dependency for vcloud-core

--- a/Rakefile
+++ b/Rakefile
@@ -8,7 +8,7 @@ ENV['COVERAGE'] = 'true'
 task.pattern = FileList['spec/**/*_spec.rb'] - FileList['spec/integration/*_spec.rb']
 end
 
-RSpec::Core::RakeTask.new(:integration_test) do |task|
+RSpec::Core::RakeTask.new(:integration) do |task|
 task.pattern = FileList['spec/integration/*_spec.rb']
 end
 


### PR DESCRIPTION
Rename the Rake task for integration tests from 'integration_test' to
'integration' to keep it consistent with other tools[1](https://github.com/alphagov/vcloud-launcher/blob/master/Rakefile#L6)[3].

[1]:
https://github.com/alphagov/vcloud-net_launcher/blob/master/Rakefile#L20

[3]:
https://github.com/alphagov/vcloud-edge_gateway/blob/master/Rakefile#L15
