### PR TITLE
Raise exception if provided invalid resource type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Current
 
+API changes:
+
+  - Vcloud::Walker::walk now returns an exception if provided an invalid
+    resource type instead of returning a `nil` object and printing the valid
+    options to STDOUT.
+
 Bugfixes:
 
   - Rename Rake integration test from 'integration_test' to 'integration' for consistency with other vCloud Tools

--- a/lib/vcloud/walker.rb
+++ b/lib/vcloud/walker.rb
@@ -8,15 +8,14 @@ require 'vcloud/walker/version'
 
 module Vcloud
   module Walker
+    VALID_RESOURCES = %w{catalogs vdcs networks edgegateways organization}
 
     def self.walk(resource_to_walk)
-      valid_options = ['catalogs', 'vdcs', 'networks',
-                        'edgegateways', 'organization']
-      if valid_options.include? resource_to_walk
-        Vcloud::Walker::Resource::Organization.send(resource_to_walk)
-      else
-         puts "Possible options are '#{valid_options.join("','")}'."
+      unless VALID_RESOURCES.include?(resource_to_walk)
+         raise "Invalid resource '#{resource_to_walk}'. Possible options are '#{VALID_RESOURCES.join("','")}'."
       end
+
+      Vcloud::Walker::Resource::Organization.send(resource_to_walk)
     end
 
   end

--- a/spec/vcloud/walker_spec.rb
+++ b/spec/vcloud/walker_spec.rb
@@ -45,12 +45,10 @@ module Vcloud
       end
 
       context "invalid resources" do
-
         it "should reject input that is not a valid resouce" do
-          result_array = Vcloud::Walker.walk("invalid")
-          result_array.should be_nil
+          expect{ Vcloud::Walker.walk("invalid") }.
+            to raise_error("Invalid resource 'invalid'. Possible options are 'catalogs','vdcs','networks','edgegateways','organization'.")
         end
-
       end
 
     end


### PR DESCRIPTION
Previously this method would return a `nil` object (implicitly) and print
the valid options to STDOUT if provided an invalid resource type.

That makes it tricky to use as a library because there's no clear indication
of failure or that you're going to get the right object type back.

Replace this with an exception that makes it clear the choice is invalid.
This makes it easier to use as a library, easier to test the output, and the
method reads more clearly particulary with regard to what's being returned.

I've also moved the valid options into a class constant to indicate that
they won't be changed at runtime.
