### PR TITLE
[#72169082] Replace methadone with optparse and tests

### DIFF
--- a/bin/vcloud-walk
+++ b/bin/vcloud-walk
@@ -1,38 +1,5 @@
 #!/usr/bin/env ruby
 
-require 'rubygems'
-require 'methadone'
-
-require 'json'
 require 'vcloud/walker'
 
-class App
-  include Methadone::Main
-  include Methadone::CLILogging
-  include Vcloud
-
-  main do |resource_to_walk|
-    walker_output = Vcloud::Walker.walk(resource_to_walk)
-    options[:yaml] ? print(walker_output.to_yaml)  :  print(JSON.pretty_generate walker_output)
-  end
-
-  on("--yaml",   "Yaml output")
-
-  arg :resource_to_walk
-
-  description '
-  Vcloud-walker is a command line tool, to describe different VMware vCloud Director 5.1 resources. It uses Fog under the hood.
-
-  Resources that can be walked using vcloud-walker are:
-    catalogs
-    vdcs
-    networks
-    edgegateways
-    organization
-
-  See https://github.com/alphagov/vcloud-walker for more info'
-
-  version Vcloud::Walker::VERSION
-
-  go!
-end
+Vcloud::Walker::Cli.new(ARGV).run

--- a/lib/vcloud/walker.rb
+++ b/lib/vcloud/walker.rb
@@ -1,6 +1,7 @@
 require 'fog'
 
 require 'vcloud/core'
+require 'vcloud/walker/cli'
 require 'vcloud/walker/vcloud_session'
 require 'vcloud/walker/fog_interface'
 require 'vcloud/walker/resource'

--- a/lib/vcloud/walker/cli.rb
+++ b/lib/vcloud/walker/cli.rb
@@ -1,0 +1,82 @@
+require 'optparse'
+require 'json'
+
+module Vcloud
+  module Walker
+    class Cli
+      def initialize(argv_array)
+        @usage_text = nil
+        @resource_type = nil
+        @options = {
+          :yaml => false,
+        }
+
+        parse(argv_array)
+      end
+
+      def run
+        begin
+          out = Vcloud::Walker.walk(@resource_type)
+          if @options[:yaml]
+            print(out.to_yaml)
+          else
+            print(JSON.pretty_generate(out))
+          end
+        rescue => e
+          $stderr.puts(e)
+          exit 1
+        end
+      end
+
+      private
+
+      def parse(args)
+        opt_parser = OptionParser.new do |opts|
+          opts.banner = <<-EOS
+Usage: #{$0} [options] resource_type
+Vcloud-walker is a command line tool, to describe different VMware vCloud Director 5.1 resources. It uses Fog under the hood.
+
+Resources that can be walked using vcloud-walker are:
+  catalogs
+  vdcs
+  networks
+  edgegateways
+  organization
+
+See https://github.com/alphagov/vcloud-walker for more info
+          EOS
+
+          opts.on("--yaml",   "Yaml output") do
+            @options[:yaml] = true
+          end
+
+          opts.on("-h", "--help", "Print usage and exit") do
+            $stderr.puts opts
+            exit
+          end
+
+          opts.on("--version", "Display version and exit") do
+            puts Vcloud::Walker::VERSION
+            exit
+          end
+        end
+
+        @usage_text = opt_parser.to_s
+        begin
+          opt_parser.parse!(args)
+        rescue OptionParser::InvalidOption => e
+          exit_error_usage(e)
+        end
+
+        exit_error_usage("must supply resource_type") unless args.size == 1
+        @resource_type = args.first
+      end
+
+      def exit_error_usage(error)
+        $stderr.puts "#{$0}: #{error}"
+        $stderr.puts @usage_text
+        exit 2
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,6 @@ if ENV['COVERAGE']
 
   SimpleCov.profiles.define 'gem' do
     add_filter '/spec/'
-    add_filter '/features/'
     add_filter '/vendor/'
 
     add_group 'Libraries', '/lib/'

--- a/spec/vcloud/walker/cli_spec.rb
+++ b/spec/vcloud/walker/cli_spec.rb
@@ -1,0 +1,169 @@
+require 'spec_helper'
+
+class CommandRun
+  attr_accessor :stdout, :stderr, :exitstatus
+
+  def initialize(args)
+    out = StringIO.new
+    err = StringIO.new
+
+    $stdout = out
+    $stderr = err
+
+    begin
+      Vcloud::Walker::Cli.new(args).run
+      @exitstatus = 0
+    rescue SystemExit => e
+      # Capture exit(n) value.
+      @exitstatus = e.status
+    end
+
+    @stdout = out.string.strip
+    @stderr = err.string.strip
+
+    $stdout = STDOUT
+    $stderr = STDERR
+  end
+end
+
+describe Vcloud::Walker::Cli do
+  subject { CommandRun.new(args) }
+  let(:mock_output) do
+    [{
+      :name => 'gruffalo',
+      :desc => { :eyes => 'orange', :tongue => 'black' },
+    },{
+      :name => 'mouse',
+      :desc => { :tail => 'scaly', :whiskers => 'wire' },
+    }]
+  end
+
+  describe "normal usage" do
+    context "when given resource_type" do
+      let(:args) { %w{things} }
+
+      it "should pass resource_type and exit normally" do
+        expect(Vcloud::Walker).to receive(:walk).with('things').and_return(mock_output)
+        expect(subject.exitstatus).to eq(0)
+      end
+    end
+
+    context "when asked to display version" do
+      let(:args) { %w{--version} }
+
+      it "should not call Walker" do
+        expect(Vcloud::Walker).not_to receive(:walk)
+      end
+
+      it "should print version and exit normally" do
+        expect(subject.stdout).to eq(Vcloud::Walker::VERSION)
+        expect(subject.exitstatus).to eq(0)
+      end
+    end
+
+    context "when asked to display help" do
+      let(:args) { %w{--help} }
+
+      it "should not call Walker" do
+        expect(Vcloud::Walker).not_to receive(:walk)
+      end
+
+      it "should print usage and exit normally" do
+        expect(subject.stderr).to match(/\AUsage: \S+ \[options\] resource_type\n/)
+        expect(subject.exitstatus).to eq(0)
+      end
+    end
+  end
+
+  describe "output formats" do
+    context "when no format is specified" do
+      let(:args) { %w{things} }
+      let(:expected_stdout) { <<EOS
+[
+  {
+    "name": "gruffalo",
+    "desc": {
+      "eyes": "orange",
+      "tongue": "black"
+    }
+  },
+  {
+    "name": "mouse",
+    "desc": {
+      "tail": "scaly",
+      "whiskers": "wire"
+    }
+  }
+]
+EOS
+      }
+
+      it "should output in JSON with no trailing newline" do
+        expect(Vcloud::Walker).to receive(:walk).with('things').and_return(mock_output)
+        expect(subject.stdout).to eq(expected_stdout.chomp)
+      end
+    end
+
+    context "when given --yaml" do
+      let(:args) { %w{--yaml things} }
+      let(:expected_stdout) { <<EOS
+---
+- :name: gruffalo
+  :desc:
+    :eyes: orange
+    :tongue: black
+- :name: mouse
+  :desc:
+    :tail: scaly
+    :whiskers: wire
+EOS
+      }
+
+      it "should output in YAML with no trailing newline" do
+        expect(Vcloud::Walker).to receive(:walk).with('things').and_return(mock_output)
+        expect(subject.stdout).to eq(expected_stdout.chomp)
+      end
+    end
+  end
+
+  describe "incorrect usage" do
+    shared_examples "print usage and exit abnormally" do |error|
+      it "should not call Walker" do
+        expect(Vcloud::Walker).not_to receive(:walk)
+      end
+
+      it "should print error message and usage" do
+        expect(subject.stderr).to match(/\A\S+: #{error}\nUsage: \S+/)
+      end
+
+      it "should exit abnormally for incorrect usage" do
+        expect(subject.exitstatus).to eq(2)
+      end
+    end
+
+    context "when given more than resource_type argument" do
+      let(:args) { %w{type_one type_two} }
+
+      it_behaves_like "print usage and exit abnormally", "must supply resource_type"
+    end
+
+    context "when given an unrecognised argument" do
+      let(:args) { %w{--this-is-garbage} }
+
+      it_behaves_like "print usage and exit abnormally", "invalid option: --this-is-garbage"
+    end
+  end
+
+  describe "error handling" do
+    context "when underlying code raises an exception" do
+      let(:args) { %w{things} }
+
+      it "should print error without backtrace and exit abnormally" do
+        expect(Vcloud::Walker).to receive(:walk).
+          with('things').and_raise("something went horribly wrong")
+        expect(subject.stderr).to eq("something went horribly wrong")
+        expect(subject.exitstatus).to eq(1)
+      end
+    end
+  end
+end

--- a/vcloud-walker.gemspec
+++ b/vcloud-walker.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec-mocks', '~> 2.14.3'
   s.add_development_dependency 'json_spec', '~> 1.1.1'
   s.add_runtime_dependency 'json', '~> 1.8.0'
-  s.add_runtime_dependency 'methadone'
   s.add_runtime_dependency 'fog', '>= 1.21.0'
   s.add_runtime_dependency 'vcloud-core', '~> 0.0.12'
   s.add_development_dependency 'simplecov', '~> 0.8.2'


### PR DESCRIPTION
This is essentially the same as alphagov/vcloud-edge_gateway#70. The
executable has been rewritten to use plain OptionParser and unit tested.

With the difference that exceptions are caught to prevent the stacktrace
being leaked to the CLI to preserve existing behaviour.
