### PR TITLE
[#73466396] Pin vCloud Core to version 0.5.0

### DIFF
--- a/vcloud-walker.gemspec
+++ b/vcloud-walker.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'fog', '>= 1.21.0'
   s.add_runtime_dependency 'json', '~> 1.8.0'
-  s.add_runtime_dependency 'vcloud-core', '~> 0.0.12'
+  s.add_runtime_dependency 'vcloud-core', '~> 0.5.0'
   s.add_development_dependency 'gem_publisher', '1.2.0'
   s.add_development_dependency 'json_spec', '~> 1.1.1'
   s.add_development_dependency 'rake'


### PR DESCRIPTION
Now that vCloud Tools Tester, a development dependency of the majority
of the vCloud Tools gems, depends on vCloud Core version 0.5.0, all gems
must use the same version of vCloud Core to prevent version conflicts.
