### PR TITLE
[#68989754] Update vcloud-core for vcloud-login utility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## UNRELEASED (2014-XX-XX)
+
+Update to vCloud Core 0.7.0 for the following:
+
+  - New vcloud-login tool for fetching session tokens without the need to
+    store your password in a plaintext FOG_RC file.
+  - Deprecate the use of :vcloud_director_password in a plaintext FOG_RC
+    file. A warning will be printed to STDERR at load time. Please use
+    vcloud-login instead.
+
 ## 3.2.3 (2014-07-14)
 
 Bugfixes:

--- a/README.md
+++ b/README.md
@@ -52,41 +52,7 @@ networks and vdcs within an organization.
 
 ## Credentials
 
-vCloud Walker is based around [fog](http://fog.io/). To use it you'll need to give it
-credentials that allow it to talk to a vCloud Director environment.
-
-1. Create a '.fog' file in your home directory.
-
-  For example:
-
-      test_credentials:
-        vcloud_director_host: 'host.api.example.com'
-        vcloud_director_username: 'username@org_name'
-        vcloud_director_password: ''
-
-2. Obtain a session token. First, curl the API:
-
-        curl -D- -d '' \
-            -H 'Accept: application/*+xml;version=5.1' -u '<username>@<org_name>' \
-            https://<host.api.example.com>/api/sessions
-
-  This will prompt for your password.
-
-  From the headers returned, the value of the `x-vcloud-authorization` header is your
-  session token, and this will be valid for 30 minutes idle - any activity will extend
-  its life by another 30 minutes.
-
-3. Specify your credentials and session token at the beginning of the command. For example:
-
-        FOG_CREDENTIAL=test_credentials \
-            FOG_VCLOUD_TOKEN=AAAABBBBBCCCCCCDDDDDDEEEEEEFFFFF= \
-            vcloud-walk organization
-
-  You may find it easier to export one or both of the values as environment variables.
-
-  **NB** It is also possible to sidestep the need for the session token by saving your
-  password in the fog file. This is **not recommended**.
-
+Please see the [vcloud-tools usage documentation](http://gds-operations.github.io/vcloud-tools/usage/).
 
 ### Output
 

--- a/vcloud-walker.gemspec
+++ b/vcloud-walker.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'fog', '>= 1.21.0'
   s.add_runtime_dependency 'json', '~> 1.8.0'
-  s.add_runtime_dependency 'vcloud-core', '~> 0.6.0'
+  s.add_runtime_dependency 'vcloud-core', '~> 0.7.0'
   s.add_development_dependency 'gem_publisher', '1.2.0'
   s.add_development_dependency 'json_spec', '~> 1.1.1'
   s.add_development_dependency 'rake'


### PR DESCRIPTION
Makes the new `vcloud-login` utility available and deprecates the use of
plaintext passwords in FOG_RC. Documentation about credentials is now
centralised.
