### PR TITLE
Bump vcloud-core dep to 0.11.0 and release 3.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.4.0 (2014-09-11)
+
+  - Upgrade dependency on vCloud Core to 0.11.0 which prevents plaintext
+    passwords in FOG_RC. Please use tokens via vcloud-login as per
+    the documentation: http://gds-operations.github.io/vcloud-tools/usage/
+
 ## 3.3.1 (2014-08-12)
 
   - Upgrade dependency on vCloud Core to 0.10.0 for parity with other vCloud

--- a/lib/vcloud/walker/version.rb
+++ b/lib/vcloud/walker/version.rb
@@ -1,5 +1,5 @@
 module Vcloud
   module Walker
-    VERSION = '3.3.1'
+    VERSION = '3.4.0'
   end
 end

--- a/vcloud-walker.gemspec
+++ b/vcloud-walker.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'fog', '>= 1.21.0'
   s.add_runtime_dependency 'json', '~> 1.8.0'
-  s.add_runtime_dependency 'vcloud-core', '~> 0.10.0'
+  s.add_runtime_dependency 'vcloud-core', '~> 0.11.0'
   s.add_development_dependency 'gem_publisher', '1.2.0'
   s.add_development_dependency 'json_spec', '~> 1.1.1'
   s.add_development_dependency 'rake'


### PR DESCRIPTION
Changes:
- plaintext passwords are no longer permissible in FOG_RC
  See http://gds-operations.github.io/vcloud-tools/usage/
