### PR TITLE
#106 - workaround for IPsec tunnels internal to a VCD

### DIFF
--- a/lib/vcloud/walker/resource/gateway_ipsec_vpn_service.rb
+++ b/lib/vcloud/walker/resource/gateway_ipsec_vpn_service.rb
@@ -19,7 +19,7 @@ module Vcloud
             @tunnel = {
               :Name => fog_vpn_tunnel[:Name],
               :Description => fog_vpn_tunnel[:Description],
-              :ThirdPartyPeerId => fog_vpn_tunnel[:IpsecVpnThirdPartyPeer][:PeerId],
+              :ThirdPartyPeerId => fog_vpn_tunnel[:PeerId],
               :PeerId => fog_vpn_tunnel[:PeerId],
               :LocalId => fog_vpn_tunnel[:LocalId],
               :PeerIpAddress => fog_vpn_tunnel[:PeerIpAddress],


### PR DESCRIPTION
This is likely not the correct solution, but it worked for what I needed at the time.
