### PR TITLE
[#84123826] Add support for local IpSec VPN tunnels 

### DIFF
--- a/lib/vcloud/walker/resource/gateway_ipsec_vpn_service.rb
+++ b/lib/vcloud/walker/resource/gateway_ipsec_vpn_service.rb
@@ -19,7 +19,6 @@ module Vcloud
             @tunnel = {
               :Name => fog_vpn_tunnel[:Name],
               :Description => fog_vpn_tunnel[:Description],
-              :ThirdPartyPeerId => fog_vpn_tunnel[:IpsecVpnThirdPartyPeer][:PeerId],
               :PeerId => fog_vpn_tunnel[:PeerId],
               :LocalId => fog_vpn_tunnel[:LocalId],
               :PeerIpAddress => fog_vpn_tunnel[:PeerIpAddress],
@@ -30,6 +29,15 @@ module Vcloud
               :IsEnabled => fog_vpn_tunnel[:IsEnabled],
               :IsOperational => fog_vpn_tunnel[:IsOperational]
             }
+
+            if (third_party_peer = fog_vpn_tunnel.fetch(:IpsecVpnThirdPartyPeer, false))
+              @tunnel[:ThirdPartyPeerId] = third_party_peer[:PeerId]
+            end
+
+            if (local_peer = fog_vpn_tunnel.fetch(:IpsecVpnLocalPeer, false))
+              @tunnel[:LocalPeerId] = local_peer[:Id]
+              @tunnel[:LocalPeerName] = local_peer[:Name]
+            end
 
             @tunnel[:SharedSecret] = "*" * 65 if fog_vpn_tunnel[:SharedSecret]
             @tunnel[:SharedSecretEncrypted] = "******" if fog_vpn_tunnel[:SharedSecretEncrypted]

--- a/spec/vcloud/walker/resource/gateway_ipsec_vpn_service_spec.rb
+++ b/spec/vcloud/walker/resource/gateway_ipsec_vpn_service_spec.rb
@@ -1,9 +1,13 @@
 require 'spec_helper'
 
 describe Vcloud::Walker::Resource::GatewayIpsecVpnService do
+  let(:gateway_vpn_service) {
+    Vcloud::Walker::Resource::GatewayIpsecVpnService.new(fog_vpn_service)
+  }
+
   context "vpn service with single tunnel" do
-    before(:all) do
-      fog_vpn_service = {
+    let(:fog_vpn_service) do
+      {
         IsEnabled: true,
         Tunnel: {
           Name: "ss_one",
@@ -36,24 +40,23 @@ describe Vcloud::Walker::Resource::GatewayIpsecVpnService do
           IsOperational: "false"
         }
       }
-
-      @gateway_vpn_service = Vcloud::Walker::Resource::GatewayIpsecVpnService.new(fog_vpn_service)
     end
+
     it "should report status of vpn service" do
-      expect(@gateway_vpn_service.IsEnabled).to eq(true)
-      expect(@gateway_vpn_service.Tunnels).not_to be_empty
+      expect(gateway_vpn_service.IsEnabled).to eq(true)
+      expect(gateway_vpn_service.Tunnels).not_to be_empty
     end
 
     context "report tunnel info" do
-      before(:all) do
-        @tunnel = @gateway_vpn_service.Tunnels.first
-      end
+      let(:tunnel) {
+        gateway_vpn_service.Tunnels.first
+      }
 
       it "with peer details" do
-        expect(@tunnel[:ThirdPartyPeerId]).to eq('1')
-        expect(@tunnel[:PeerId]).to eq('1')
-        expect(@tunnel[:PeerIpAddress]).to eq('8.8.8.8')
-        expect(@tunnel[:PeerSubnet]).to eq({
+        expect(tunnel[:ThirdPartyPeerId]).to eq('1')
+        expect(tunnel[:PeerId]).to eq('1')
+        expect(tunnel[:PeerIpAddress]).to eq('8.8.8.8')
+        expect(tunnel[:PeerSubnet]).to eq({
                                              Name: "8.8.8.0/8",
                                              Gateway: "8.8.8.0",
                                              Netmask: "255.0.0.0"
@@ -61,9 +64,9 @@ describe Vcloud::Walker::Resource::GatewayIpsecVpnService do
       end
 
       it "with local network details" do
-        expect(@tunnel[:LocalId]).to eq('1')
-        expect(@tunnel[:LocalIpAddress]).to eq('192.0.2.1')
-        expect(@tunnel[:LocalSubnet]).to eq({
+        expect(tunnel[:LocalId]).to eq('1')
+        expect(tunnel[:LocalIpAddress]).to eq('192.0.2.1')
+        expect(tunnel[:LocalSubnet]).to eq({
                                               Name: "Default",
                                               Gateway: "192.168.0.1",
                                               Netmask: "255.255.0.0"
@@ -71,88 +74,90 @@ describe Vcloud::Walker::Resource::GatewayIpsecVpnService do
       end
 
       it "with maximum transmission unit" do
-        expect(@tunnel[:Mtu]).to eq('1500')
+        expect(tunnel[:Mtu]).to eq('1500')
       end
 
       it "with masked vpn shared secret information" do
-        expect(@tunnel[:SharedSecret]).to eq("*" * 65)
-        expect(@tunnel[:SharedSecretEncrypted]).to eq("******")
-        expect(@tunnel[:EncryptionProtocol]).to eq("******")
+        expect(tunnel[:SharedSecret]).to eq("*" * 65)
+        expect(tunnel[:SharedSecretEncrypted]).to eq("******")
+        expect(tunnel[:EncryptionProtocol]).to eq("******")
       end
 
       it "should skip any addditional vpn details provided by fog" do
-        expect(@tunnel[:AdditionalDetails]).to be_nil
+        expect(tunnel[:AdditionalDetails]).to be_nil
       end
     end
-
   end
 
-  it "should report vpn service with multiple tunnels" do
-    fog_vpn_service = {
-      IsEnabled: true,
-      Tunnel: [
-        {
-          Name: "remove vpn 1",
-          Description: "describe me",
-          IpsecVpnThirdPartyPeer: {
-            PeerId: "1"
-          },
-          PeerIpAddress: "8.8.8.8",
-          PeerId: "1",
-          LocalIpAddress: "192.0.2.1",
-          LocalId: "1",
-          LocalSubnet: {
-            Name: "Default",
-            Gateway: "192.168.0.1",
-            Netmask: "255.255.0.0"
-          },
-          PeerSubnet: {
-            Name: "8.8.8.0/8",
-            Gateway: "8.8.8.0",
-            Netmask: "255.0.0.0"
-          },
-          SharedSecret: "DoNotDiscloseDoNotDiscloseDoNotDiscloseDoNotDiscloseDoNotDisclose",
-          SharedSecretEncrypted: "false",
-          EncryptionProtocol: "AES256",
-          Mtu: "1500",
-          AdditionalDetails: {
-            shared_network: true
-          },
-          IsEnabled: "true",
-          IsOperational: "false"
-        },
-        {
-          Name: "remote vpn 2",
-          Description: "describe me",
-          IpsecVpnThirdPartyPeer: {
-            PeerId: "2"
-          },
-          PeerIpAddress: "8.8.4.4",
-          PeerId: "2",
-          LocalIpAddress: "172.26.2.3",
-          LocalId: "2",
-          LocalSubnet: {
-            Name: "Default",
-            Gateway: "192.168.0.1",
-            Netmask: "255.255.0.0"
-          },
-          PeerSubnet: {
-            Name: "8.8.4.4/8",
-            Gateway: "8.8.4.4",
-            Netmask: "255.0.0.0"
-          },
-          SharedSecret: "PrivyPrivyPrivyPrivyPrivyPrivyPrivyPrivyPrivyPrivy",
-          SharedSecretEncrypted: "false",
-          EncryptionProtocol: "AES256",
-          Mtu: "1500",
-          IsEnabled: "true",
-          IsOperational: "false"
-        }
-      ]
-    }
+  context "vpn service with multiple tunnels" do
 
-    gateway_vpn_service = Vcloud::Walker::Resource::GatewayIpsecVpnService.new(fog_vpn_service)
-    expect(gateway_vpn_service.Tunnels.count).to eq(2)
+    let(:fog_vpn_service) do
+      {
+        IsEnabled: true,
+        Tunnel: [
+          {
+            Name: "remove vpn 1",
+            Description: "describe me",
+            IpsecVpnThirdPartyPeer: {
+              PeerId: "1"
+            },
+            PeerIpAddress: "8.8.8.8",
+            PeerId: "1",
+            LocalIpAddress: "192.0.2.1",
+            LocalId: "1",
+            LocalSubnet: {
+              Name: "Default",
+              Gateway: "192.168.0.1",
+              Netmask: "255.255.0.0"
+            },
+            PeerSubnet: {
+              Name: "8.8.8.0/8",
+              Gateway: "8.8.8.0",
+              Netmask: "255.0.0.0"
+            },
+            SharedSecret: "DoNotDiscloseDoNotDiscloseDoNotDiscloseDoNotDiscloseDoNotDisclose",
+            SharedSecretEncrypted: "false",
+            EncryptionProtocol: "AES256",
+            Mtu: "1500",
+            AdditionalDetails: {
+              shared_network: true
+            },
+            IsEnabled: "true",
+            IsOperational: "false"
+          },
+          {
+            Name: "remote vpn 2",
+            Description: "describe me",
+            IpsecVpnThirdPartyPeer: {
+              PeerId: "2"
+            },
+            PeerIpAddress: "8.8.4.4",
+            PeerId: "2",
+            LocalIpAddress: "172.26.2.3",
+            LocalId: "2",
+            LocalSubnet: {
+              Name: "Default",
+              Gateway: "192.168.0.1",
+              Netmask: "255.255.0.0"
+            },
+            PeerSubnet: {
+              Name: "8.8.4.4/8",
+              Gateway: "8.8.4.4",
+              Netmask: "255.0.0.0"
+            },
+            SharedSecret: "PrivyPrivyPrivyPrivyPrivyPrivyPrivyPrivyPrivyPrivy",
+            SharedSecretEncrypted: "false",
+            EncryptionProtocol: "AES256",
+            Mtu: "1500",
+            IsEnabled: "true",
+            IsOperational: "false"
+          }
+        ]
+      }
+    end
+
+    it "should report vpn service with multiple tunnels" do
+      expect(gateway_vpn_service.Tunnels.count).to eq(2)
+    end
   end
-
 end

--- a/spec/vcloud/walker/resource/gateway_ipsec_vpn_service_spec.rb
+++ b/spec/vcloud/walker/resource/gateway_ipsec_vpn_service_spec.rb
@@ -50,6 +50,7 @@ describe Vcloud::Walker::Resource::GatewayIpsecVpnService do
       end
 
       it "with peer details" do
+        expect(@tunnel[:ThirdPartyPeerId]).to eq('1')
         expect(@tunnel[:PeerId]).to eq('1')
         expect(@tunnel[:PeerIpAddress]).to eq('8.8.8.8')
         expect(@tunnel[:PeerSubnet]).to eq({

--- a/spec/vcloud/walker/resource/gateway_ipsec_vpn_service_spec.rb
+++ b/spec/vcloud/walker/resource/gateway_ipsec_vpn_service_spec.rb
@@ -89,6 +89,55 @@ describe Vcloud::Walker::Resource::GatewayIpsecVpnService do
     end
   end
 
+  context "vpn service with inter-vDC tunnel" do
+    let(:fog_vpn_service) do
+      {
+        IsEnabled: true,
+        Tunnel: {
+          Name: "ss_one",
+          Description: "desc one",
+          IpsecVpnLocalPeer: {
+            Id: "1",
+            Name: "Foo",
+          },
+          PeerIpAddress: "8.8.8.8",
+          PeerId: "1",
+          LocalIpAddress: "192.0.2.1",
+          LocalId: "1",
+          LocalSubnet: {
+            Name: "Default",
+            Gateway: "192.168.0.1",
+            Netmask: "255.255.0.0"
+          },
+          PeerSubnet: [
+            {
+              Name: "Bar",
+              Gateway: "10.0.0.1",
+              Netmask: "255.255.255.0"
+            },
+          ],
+          SharedSecret: "DoNotDiscloseDoNotDiscloseDoNotDiscloseDoNotDiscloseDoNotDisclose",
+          SharedSecretEncrypted: "false",
+          EncryptionProtocol: "AES256",
+          Mtu: "1500",
+          IsEnabled: "true",
+          IsOperational: "false"
+        }
+      }
+    end
+
+    context "report tunnel info" do
+      let(:tunnel) {
+        gateway_vpn_service.Tunnels.first
+      }
+
+      it "returns accurate local peer details" do
+        expect(tunnel[:LocalPeerId]).to eq('1')
+        expect(tunnel[:LocalPeerName]).to eq('Foo')
+      end
+    end
+  end
+
   context "vpn service with multiple tunnels" do
 
     let(:fog_vpn_service) do


### PR DESCRIPTION
Support local IpSec VPN tunnels, such as an intra-vDC tunnel.

Local tunnels provide both an `:Id` and a `:Name` key, as determined
from this debugging session (please note, private link):
https://github.gds/gist/mattbostock/ba95460918bd7d3ada5e#file-vcloud-walker-pry-rb-L47

@rjw1: I'd be grateful if you could please test this branch on the vCloud organisation where you noticed the bug previously.

This fixes #106.