### PR TITLE
Relax dependency on vcloud-core

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 ---
 language: ruby
 rvm:
-  - 1.9.3
   - 2.0.0
   - 2.1.2
 notifications:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 5.0.0 (2015-10-20)
+
+  - Remove support for Ruby 1.9.3.
+  - Relax dependency on vCloud Core to anything in the 1.x branch to
+    make installing this gem alongside other vCloud gems easier.
+
 ## 4.0.0 (2015-01-22)
 
   - Update dependency on vCloud Core to 1.0.0 since it is now stable.

--- a/lib/vcloud/walker/version.rb
+++ b/lib/vcloud/walker/version.rb
@@ -1,5 +1,5 @@
 module Vcloud
   module Walker
-    VERSION = '4.0.0'
+    VERSION = '5.0.0'
   end
 end

--- a/vcloud-walker.gemspec
+++ b/vcloud-walker.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'fog', '>= 1.21.0'
   s.add_runtime_dependency 'json', '~> 1.8.0'
-  s.add_runtime_dependency 'vcloud-core', '~> 1.0.0'
+  s.add_runtime_dependency 'vcloud-core', '~> 1.0'
   s.add_development_dependency 'gem_publisher', '1.2.0'
   s.add_development_dependency 'json_spec', '~> 1.1.1'
   s.add_development_dependency 'rake'


### PR DESCRIPTION
This repository doesn't require a specific version of vcloud-core
at the moment, so we can relax the dependency so that installing this
gem alongside the other vCloud gems is easier.