### PR TITLE
[#102487834] Explicitly set RBENV_VERSION

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -2,4 +2,6 @@
 set -e
 
 ./jenkins_tests.sh
+
+source ./rbenv_version.sh
 bundle exec rake publish_gem

--- a/jenkins_tests.sh
+++ b/jenkins_tests.sh
@@ -19,6 +19,9 @@ ${FOG_CREDENTIAL}:
 EOF
 
 rm -f Gemfile.lock
+
+source ./rbenv_version.sh
+
 git clean -fdx
 
 bundle install --path "${HOME}/bundles/${JOB_NAME}"

--- a/rbenv_version.sh
+++ b/rbenv_version.sh
@@ -1,0 +1,1 @@
+export RBENV_VERSION="2.0.0"


### PR DESCRIPTION
Explicitly set the Ruby version with which to run our Jenkins
integration tests.

Set `RBENV_VERSION` by sourcing `./rbenv_version.sh` before invoking
Rake to prevent the `bundle` command from failing because no Ruby
version is set.

It's necessary to source `./rbenv_version.sh` in both `jenkins.sh` and
`jenkins_tests.sh` because we run the former in Carrenza but the latter
in Skyscape; we only publish the gem once the tests have passed for both
suppliers.

I'm intentionally avoiding use of `.ruby-version` to avoid new users
from inferring that Ruby version 2.0.0 is the only Ruby version this
tool supports.