### PR TITLE
Update Markdown link syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,4 +88,4 @@ See the [vCloud Tools website](http://gds-operations.github.io/vcloud-tools/test
 
 ## Contributing
 
-Please see [CONTRIBUTING.md].
+Please see [CONTRIBUTING.md](/CONTRIBUTING.md).


### PR DESCRIPTION
Realised after I'd merged this that the syntax for linking to the CONTRIBUTING file still needs the reference in order to be a link.