### PR TITLE
Release 5.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 5.1.0 (2017-06-23)
+
+  - Remove support for any Ruby older than v2.2.2.
+  - Add support for Ruby 2.3.0 and 2.4.0.
+  - Various bug fixes
+  - Updated dependencies
+
 ## 5.0.0 (2015-10-20)
 
   - Remove support for Ruby 1.9.3.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,7 +25,7 @@ node {
 
     if (env.BRANCH_NAME == "master") {
       stage("Publish gem") {
-        sh('bundle exec rake publish_gem')
+        govuk.publishGem(repoName, env.BRANCH_NAME)
       }
     }
   } catch (e) {

--- a/lib/vcloud/walker/version.rb
+++ b/lib/vcloud/walker/version.rb
@@ -1,5 +1,5 @@
 module Vcloud
   module Walker
-    VERSION = '5.0.0'
+    VERSION = '5.1.0'
   end
 end

--- a/vcloud-walker.gemspec
+++ b/vcloud-walker.gemspec
@@ -20,10 +20,10 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.2.2'
 
-  s.add_runtime_dependency 'fog', '>= 1.21.0'
+  s.add_runtime_dependency 'fog', '>= 1.40.0'
   s.add_runtime_dependency 'json', '~> 1.8.0'
   s.add_runtime_dependency 'nokogiri', '~> 1.6.8.1'
-  s.add_runtime_dependency 'vcloud-core', '~> 2.0'
+  s.add_runtime_dependency 'vcloud-core', '~> 2.1.0'
   s.add_development_dependency 'gem_publisher', '1.2.0'
   s.add_development_dependency 'json_spec', '~> 1.1.1'
   s.add_development_dependency 'rake', '>= 12'

--- a/vcloud-walker.gemspec
+++ b/vcloud-walker.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.test_files    = s.files.grep(%r{^(test|spec|features)/})
   s.require_paths = ["lib"]
 
-  s.required_ruby_version = '>= 2.0.0'
+  s.required_ruby_version = '>= 2.2.2'
 
   s.add_runtime_dependency 'fog', '>= 1.21.0'
   s.add_runtime_dependency 'json', '~> 1.8.0'


### PR DESCRIPTION
vCloud Walker is on a higher version number than the rest of vCloud Tools.

I considered moving the release to make the version numbers match up again, but decided just to stick.

https://trello.com/c/0uDbDpkt/574-update-dependencies-on-vcloud-tools